### PR TITLE
fix font loading in final bundle

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,10 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { ElectronService } from './providers/electron.service';
 
 @Component({
     selector: 'app-root',
     templateUrl: './app.component.html',
-    styleUrls: ['./app.component.scss'],
-    styles: [
-        require ('opensans-npm-webfont')
-    ],
-    encapsulation: ViewEncapsulation.None
+    styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
     constructor(public electronService: ElectronService) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,6 @@
+@import "~opensans-npm-webfont/open_sans.css";
+@import "~opensans-npm-webfont/open_sans_bold.css";
+
 html, body {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Until now a build with ie `npm run electron:linux` created a bundle not containing any font files. This PR fixes this.